### PR TITLE
Add README describing site and local preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Joshua Berkoh Personal Website
+
+This repository contains the source for [joshberk.github.io](https://joshberk.github.io), a static site showcasing Joshua Berkoh's cybersecurity work, résumé and blog posts.
+
+## Previewing Locally
+
+Clone the repository and start a simple HTTP server from the project root:
+
+```bash
+python3 -m http.server
+```
+
+Then open `http://localhost:8000` in your browser to view the site.
+
+## Deployment
+
+The site is deployed through **GitHub Pages**. Pushing changes to the `main` branch will automatically update the live site.
+
+## Editing Blog Posts
+
+See [BLOG_CUSTOMIZATION_GUIDE.md](BLOG_CUSTOMIZATION_GUIDE.md) for details on customizing and adding blog posts.


### PR DESCRIPTION
## Summary
- add README at repo root outlining the site purpose
- explain how to preview locally and deployment via GitHub Pages
- link to BLOG_CUSTOMIZATION_GUIDE for editing posts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863fa19ae0c8330a719c2ba228c4bcc