### PR TITLE
refactor: replace inline year scripts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -87,9 +87,7 @@
     <footer>
       <p>
         &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
+        <span id="year"></span>
         Joshua Offe Berkoh. All rights reserved.
         &nbsp;|&nbsp; Built with care by Joshua.
       </p>

--- a/blog/appsec-lessons.html
+++ b/blog/appsec-lessons.html
@@ -82,9 +82,7 @@
     <footer>
       <p>
         &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
+        <span id="year"></span>
         Joshua Offe Berkoh. All rights reserved.
         &nbsp;|&nbsp; Built with care by Joshua.
       </p>

--- a/blog/apt-demystified.html
+++ b/blog/apt-demystified.html
@@ -79,9 +79,7 @@
     <footer>
       <p>
         &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
+        <span id="year"></span>
         Joshua Offe Berkoh. All rights reserved.
         &nbsp;|&nbsp; Built with care by Joshua.
       </p>

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -82,9 +82,7 @@
     <footer>
       <p>
         &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
+        <span id="year"></span>
         Joshua Offe Berkoh. All rights reserved.
         &nbsp;|&nbsp; Built with care by Joshua.
       </p>

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -79,9 +79,7 @@
     <footer>
       <p>
         &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
+        <span id="year"></span>
         Joshua Offe Berkoh. All rights reserved.
         &nbsp;|&nbsp; Built with care by Joshua.
       </p>

--- a/index.html
+++ b/index.html
@@ -330,9 +330,7 @@
     <footer>
       <p>
         &copy;
-        <script>
-          document.write(new Date().getFullYear());
-        </script>
+        <span id="year"></span>
         Joshua Offe Berkoh. All rights reserved.
         &nbsp;|&nbsp; Built with care by Joshua.
       </p>

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const navLinks = document.querySelectorAll('.navbar a');
   const hamburger = document.querySelector('.hamburger');
   const sections = document.querySelectorAll('main section');
+  const yearSpan = document.getElementById('year');
+
+  if (yearSpan) {
+    yearSpan.textContent = new Date().getFullYear();
+  }
 
   // Add background and shadow when scrolled beyond a certain amount
   window.addEventListener('scroll', () => {


### PR DESCRIPTION
## Summary
- replace inline `document.write` year scripts on all pages with `<span id="year"></span>`
- populate the year span in `js/main.js`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689025cc47308330a4ea1aff03085be2