### PR TITLE
Use accent-text class for hero heading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,6 +68,11 @@ h1, h2, h3, h4 {
   font-weight: 600;
 }
 
+/* Accent text utility */
+.accent-text {
+  color: var(--accent-color);
+}
+
 .container {
   width: 90%;
   max-width: 1100px;

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     <!-- Hero Section -->
     <section id="hero" class="hero" aria-label="Introduction">
       <div class="hero-content">
-        <h1>Hi, I'm <span style="color: var(--accent-color)">Joshua Offe Berkoh</span></h1>
+        <h1>Hi, I'm <span class="accent-text">Joshua Offe Berkoh</span></h1>
         <p>
           PhD candidate and aspiring applied scientist in cryptography, building
           secure systems and exploring the frontiers of cybersecurity.


### PR DESCRIPTION
## Summary
- replace inline style on hero heading with `accent-text` class for cleaner markup
- add `.accent-text` utility class in CSS to reuse accent color

## Testing
- `rg 'style=' -n index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890279973e08330a29dff72e1812467