### PR TITLE
Track theme toggle pressed state for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       </ul>
 
       <!-- Theme toggle button: shows moon for night mode and sun for day mode -->
-      <button id="themeToggle" class="theme-toggle" aria-label="Switch to night mode">🌙</button>
+      <button id="themeToggle" class="theme-toggle" aria-label="Switch to night mode" aria-pressed="false">🌙</button>
     </nav>
 
     <main>

--- a/js/main.js
+++ b/js/main.js
@@ -107,15 +107,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme) {
       applyTheme(savedTheme);
+      themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
     } else {
       // Default to light theme if nothing saved
       applyTheme('light');
+      themeToggle.setAttribute('aria-pressed', 'false');
     }
 
     // Toggle the theme when the user clicks the button
     themeToggle.addEventListener('click', () => {
-      const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
-      const next = current === 'dark' ? 'light' : 'dark';
+      const isPressed = themeToggle.getAttribute('aria-pressed') === 'true';
+      const next = isPressed ? 'light' : 'dark';
+      themeToggle.setAttribute('aria-pressed', (!isPressed).toString());
       applyTheme(next);
       localStorage.setItem('theme', next);
     });


### PR DESCRIPTION
## Summary
- add `aria-pressed="false"` default to theme toggle button
- persist and flip `aria-pressed` in `main.js` when switching themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689028d40c5c83309f6d6906a49b2d0b