### PR TITLE
fix: ensure mobile nav links are readable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -598,11 +598,12 @@ footer a:hover {
     right: -100%;
     width: 200px;
     height: 100vh;
-    background-color: #ffffff;
+    background-color: var(--card-bg);
     flex-direction: column;
     padding-top: 80px;
     transition: right 0.4s ease;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    color: var(--text-color);
   }
   .navbar ul.open {
     right: 0;


### PR DESCRIPTION
## Summary
- make mobile navigation menu text legible by setting text color
- use theme variables for mobile nav menu background

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6890312d01b883308bf8ac432a9f1616