### PR TITLE
Add Open Graph metadata and keywords for better sharing

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -7,6 +7,14 @@
       name="description"
       content="Blog posts by Joshua Offe Berkoh, exploring cryptography, cybersecurity and research experiences."
     />
+    <meta name="keywords" content="Joshua Berkoh blog, cryptography, cybersecurity, research, articles" />
+    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta
+      property="og:description"
+      content="Blog posts by Joshua Offe Berkoh, exploring cryptography, cybersecurity and research experiences."
+    />
+    <meta property="og:url" content="https://joshberk.github.io/blog.html" />
+    <meta property="og:image" content="assets/images/preview.png" />
     <title>Blog | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="css/style.css" />
   </head>

--- a/blog/appsec-lessons.html
+++ b/blog/appsec-lessons.html
@@ -7,6 +7,14 @@
       name="description"
       content="Lessons learned from Joshua Offe Berkoh’s participation in the Security Innovation AppSec Challenge."
     />
+    <meta name="keywords" content="AppSec, security, CTF, vulnerabilities, Joshua Berkoh" />
+    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta
+      property="og:description"
+      content="Lessons learned from Joshua Offe Berkoh’s participation in the Security Innovation AppSec Challenge."
+    />
+    <meta property="og:url" content="https://joshberk.github.io/blog/appsec-lessons.html" />
+    <meta property="og:image" content="../assets/images/preview.png" />
     <title>Lessons from the AppSec Challenge | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
   </head>

--- a/blog/apt-demystified.html
+++ b/blog/apt-demystified.html
@@ -7,6 +7,14 @@
       name="description"
       content="An exploration of advanced persistent threats and proactive defence strategies by Joshua Offe Berkoh."
     />
+    <meta name="keywords" content="advanced persistent threats, cybersecurity, defence, Joshua Berkoh" />
+    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta
+      property="og:description"
+      content="An exploration of advanced persistent threats and proactive defence strategies by Joshua Offe Berkoh."
+    />
+    <meta property="og:url" content="https://joshberk.github.io/blog/apt-demystified.html" />
+    <meta property="og:image" content="../assets/images/preview.png" />
     <title>Demystifying Advanced Persistent Threats | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
   </head>

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -7,6 +7,14 @@
       name="description"
       content="Reflections on transitioning into cryptography, exploring the need for rigorous security definitions and mathematical foundations."
     />
+    <meta name="keywords" content="cryptography, career transition, security research, Joshua Berkoh" />
+    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta
+      property="og:description"
+      content="Reflections on transitioning into cryptography, exploring the need for rigorous security definitions and mathematical foundations."
+    />
+    <meta property="og:url" content="https://joshberk.github.io/blog/pivoting-cryptography.html" />
+    <meta property="og:image" content="../assets/images/preview.png" />
     <title>Pivoting to Cryptography With Purpose | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
   </head>

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -7,6 +7,14 @@
       name="description"
       content="An accessible introduction to key cryptographic concepts, covering encryption, decryption and the differences between symmetric and asymmetric schemes."
     />
+    <meta name="keywords" content="encryption, cryptography basics, symmetric, asymmetric, study notes, Joshua Berkoh" />
+    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta
+      property="og:description"
+      content="An accessible introduction to key cryptographic concepts, covering encryption, decryption and the differences between symmetric and asymmetric schemes."
+    />
+    <meta property="og:url" content="https://joshberk.github.io/blog/week-1-foundational-encryption-concepts.html" />
+    <meta property="og:image" content="../assets/images/preview.png" />
     <title>Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
   </head>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,14 @@
       name="description"
       content="Personal portfolio of Joshua Offe Berkoh, a PhD student in information technology with a passion for applied cryptography and cybersecurity."
     />
+    <meta name="keywords" content="Joshua Berkoh, cryptography, cybersecurity, PhD, portfolio, research" />
+    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta
+      property="og:description"
+      content="Personal portfolio of Joshua Offe Berkoh, a PhD student in information technology with a passion for applied cryptography and cybersecurity."
+    />
+    <meta property="og:url" content="https://joshberk.github.io/" />
+    <meta property="og:image" content="assets/images/preview.png" />
     <title>Joshua Offe Berkoh | Cryptography & Cybersecurity</title>
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
## Summary
- add `keywords` meta tags to improve SEO across landing page, blog index, and individual posts
- embed Open Graph tags (`og:title`, `og:description`, `og:url`, `og:image`) to produce rich link previews

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890a53681c883308596c409afaeb22b