### PR TITLE
Highlight active navigation links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,8 +131,14 @@ h1, h2, h3, h4 {
   transition: color 0.3s ease;
 }
 
-.navbar ul li a:hover, .navbar ul li a.active {
+
+.navbar ul li a:hover,
+.navbar ul li a.active {
   color: var(--primary-color);
+}
+
+.navbar ul li a.active {
+  border-bottom: 2px solid var(--primary-color);
 }
 
 /* Hamburger menu styles for mobile navigation */

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <body>
     <!-- Navigation Bar -->
     <nav class="navbar">
-      <a href="#hero" class="brand">Joshua O. Berkoh</a>
+        <a href="#hero" class="brand active">Joshua O. Berkoh</a>
       <button class="hamburger" aria-label="Toggle navigation" aria-controls="nav-menu" aria-expanded="false" type="button">
         <span></span>
         <span></span>

--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const sections = document.querySelectorAll('main section');
   const yearSpan = document.getElementById('year');
 
+  // Mark the top section as active on initial load
+  const heroLink = document.querySelector('.navbar a[href="#hero"]');
+  if (heroLink && document.getElementById('hero')) {
+    heroLink.classList.add('active');
+  }
+
   if (yearSpan) {
     yearSpan.textContent = new Date().getFullYear();
   }


### PR DESCRIPTION
## Summary
- accent active navigation link with a bottom border for clarity
- default the homepage hero link to active on load
- mark the brand link as active on the index page for consistency

## Testing
- `npx --yes prettier --check css/style.css index.html js/main.js` *(fails: code style issues found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890a538c19c83308af03507f959b542