### PR TITLE
Refine nav link targeting and highlight active item

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,8 +131,13 @@ h1, h2, h3, h4 {
   transition: color 0.3s ease;
 }
 
-.navbar ul li a:hover, .navbar ul li a.active {
+.navbar ul li a:hover,
+.navbar ul li a.active {
   color: var(--primary-color);
+}
+
+.navbar ul li a.active {
+  text-decoration: underline;
 }
 
 /* Hamburger menu styles for mobile navigation */

--- a/js/main.js
+++ b/js/main.js
@@ -11,7 +11,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const navbar = document.querySelector('.navbar');
   const navMenu = document.querySelector('.navbar ul');
-  const navLinks = document.querySelectorAll('.navbar a');
+  // Select only navigation links within the menu list, excluding brand links
+  const navLinks = document.querySelectorAll('.navbar ul li a');
   const hamburger = document.querySelector('.hamburger');
   const sections = document.querySelectorAll('main section');
   const yearSpan = document.getElementById('year');


### PR DESCRIPTION
## Summary
- Limit nav link selection to list items only and ignore brand links
- Underline the active nav link for clearer feedback

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890a54f77688330ab722327cb867250