### PR TITLE
Align Open Graph titles with page titles

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -8,7 +8,7 @@
       content="Blog posts by Joshua Offe Berkoh, exploring cryptography, cybersecurity and research experiences."
     />
     <meta name="keywords" content="Joshua Berkoh blog, cryptography, cybersecurity, research, articles" />
-    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta property="og:title" content="Blog | Joshua Offe Berkoh" />
     <meta
       property="og:description"
       content="Blog posts by Joshua Offe Berkoh, exploring cryptography, cybersecurity and research experiences."

--- a/blog/appsec-lessons.html
+++ b/blog/appsec-lessons.html
@@ -8,7 +8,7 @@
       content="Lessons learned from Joshua Offe Berkoh’s participation in the Security Innovation AppSec Challenge."
     />
     <meta name="keywords" content="AppSec, security, CTF, vulnerabilities, Joshua Berkoh" />
-    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta property="og:title" content="Lessons from the AppSec Challenge | Joshua Offe Berkoh" />
     <meta
       property="og:description"
       content="Lessons learned from Joshua Offe Berkoh’s participation in the Security Innovation AppSec Challenge."

--- a/blog/apt-demystified.html
+++ b/blog/apt-demystified.html
@@ -8,7 +8,7 @@
       content="An exploration of advanced persistent threats and proactive defence strategies by Joshua Offe Berkoh."
     />
     <meta name="keywords" content="advanced persistent threats, cybersecurity, defence, Joshua Berkoh" />
-    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta property="og:title" content="Demystifying Advanced Persistent Threats | Joshua Offe Berkoh" />
     <meta
       property="og:description"
       content="An exploration of advanced persistent threats and proactive defence strategies by Joshua Offe Berkoh."

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -8,7 +8,7 @@
       content="Reflections on transitioning into cryptography, exploring the need for rigorous security definitions and mathematical foundations."
     />
     <meta name="keywords" content="cryptography, career transition, security research, Joshua Berkoh" />
-    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta property="og:title" content="Pivoting to Cryptography With Purpose | Joshua Offe Berkoh" />
     <meta
       property="og:description"
       content="Reflections on transitioning into cryptography, exploring the need for rigorous security definitions and mathematical foundations."

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -8,7 +8,7 @@
       content="An accessible introduction to key cryptographic concepts, covering encryption, decryption and the differences between symmetric and asymmetric schemes."
     />
     <meta name="keywords" content="encryption, cryptography basics, symmetric, asymmetric, study notes, Joshua Berkoh" />
-    <meta property="og:title" content="Joshua Berkoh – Cryptography PhD" />
+    <meta property="og:title" content="Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh" />
     <meta
       property="og:description"
       content="An accessible introduction to key cryptographic concepts, covering encryption, decryption and the differences between symmetric and asymmetric schemes."


### PR DESCRIPTION
## Summary
- Ensure each blog post's Open Graph title mirrors its page title for accurate link previews.
- Sync the blog index page's Open Graph title with its own `<title>` tag.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6890aa138c1883309129389e44bd9721