### PR TITLE
Add Node-based smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ python3 -m http.server
 
 Then navigate to `http://localhost:8000` in your browser.
 
+## Testing
+
+Simple smoke tests check that key pages include the expected content. Run the tests with:
+
+```bash
+npm test
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "joshberk.github.io",
+  "version": "1.0.0",
+  "description": "This repository contains the source code for [Josh Berk's personal website](https://joshberk.github.io). It hosts the site's HTML, CSS, JavaScript, and related assets.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,0 +1,13 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+test('index.html includes expected title', async () => {
+  const filePath = path.join(__dirname, '..', 'index.html');
+  const content = await fs.readFile(filePath, 'utf8');
+  assert.match(
+    content,
+    /<title>Joshua Offe Berkoh \| Cryptography & Cybersecurity<\/title>/,
+  );
+});


### PR DESCRIPTION
## Summary
- initialize npm project with test script
- add smoke test verifying main page title
- document how to run tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890bd7ef43c83309c2fff67313021cb