### PR TITLE
feat: replace Plausible with Google Analytics

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -17,7 +17,14 @@
     <meta property="og:image" content="assets/images/preview.png" />
     <title>Blog | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="css/style.css" />
-    <script defer data-domain="joshberk.github.io" src="https://plausible.io/js/script.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/appsec-lessons.html
+++ b/blog/appsec-lessons.html
@@ -17,7 +17,14 @@
     <meta property="og:image" content="../assets/images/preview.png" />
     <title>Lessons from the AppSec Challenge | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
-    <script defer data-domain="joshberk.github.io" src="https://plausible.io/js/script.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/apt-demystified.html
+++ b/blog/apt-demystified.html
@@ -17,7 +17,14 @@
     <meta property="og:image" content="../assets/images/preview.png" />
     <title>Demystifying Advanced Persistent Threats | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
-    <script defer data-domain="joshberk.github.io" src="https://plausible.io/js/script.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -17,7 +17,14 @@
     <meta property="og:image" content="../assets/images/preview.png" />
     <title>Pivoting to Cryptography With Purpose | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
-    <script defer data-domain="joshberk.github.io" src="https://plausible.io/js/script.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -17,7 +17,14 @@
     <meta property="og:image" content="../assets/images/preview.png" />
     <title>Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
-    <script defer data-domain="joshberk.github.io" src="https://plausible.io/js/script.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -18,7 +18,14 @@
     <title>Joshua Offe Berkoh | Cryptography & Cybersecurity</title>
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />
-    <script defer data-domain="joshberk.github.io" src="https://plausible.io/js/script.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1234567890"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-1234567890');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->


### PR DESCRIPTION
## Summary
- swap Plausible analytics for Google Analytics `gtag.js` snippet across all pages
- ensure each page now loads the new tracking script with measurement ID

## Testing
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/blog.html`
- `curl -I http://localhost:8000/blog/appsec-lessons.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890bd6335948330bdee24912824119e