### PR TITLE
Fix Open Graph image references

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -14,7 +14,7 @@
       content="Blog posts by Joshua Offe Berkoh, exploring cryptography, cybersecurity and research experiences."
     />
     <meta property="og:url" content="https://joshberk.github.io/blog.html" />
-    <meta property="og:image" content="assets/images/preview.png" />
+    <meta property="og:image" content="assets/images/hero.png" />
     <title>Blog | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="css/style.css" />
         <!-- Google tag (gtag.js) -->

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -14,7 +14,7 @@
       content="Reflections on transitioning into cryptography, exploring the need for rigorous security definitions and mathematical foundations."
     />
     <meta property="og:url" content="https://joshberk.github.io/blog/pivoting-cryptography.html" />
-    <meta property="og:image" content="../assets/images/preview.png" />
+    <meta property="og:image" content="../assets/images/hero.png" />
     <title>Pivoting to Cryptography With Purpose | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -14,7 +14,7 @@
       content="An accessible introduction to key cryptographic concepts, covering encryption, decryption and the differences between symmetric and asymmetric schemes."
     />
     <meta property="og:url" content="https://joshberk.github.io/blog/week-1-foundational-encryption-concepts.html" />
-    <meta property="og:image" content="../assets/images/preview.png" />
+    <meta property="og:image" content="../assets/images/hero.png" />
     <title>Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
    <!-- Google tag (gtag.js) -->

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
       content="Personal portfolio of Joshua Offe Berkoh, a PhD student in information technology with a passion for applied cryptography and cybersecurity."
     />
     <meta property="og:url" content="https://joshberk.github.io/" />
-    <meta property="og:image" content="assets/images/preview.png" />
+    <meta property="og:image" content="assets/images/hero.png" />
     <title>Joshua Offe Berkoh | Cryptography & Cybersecurity</title>
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
## Summary
- point all Open Graph image tags to existing `assets/images/hero.png`

## Testing
- `npm test`
- `curl -s http://localhost:8000/index.html | rg "og:image"`
- `curl -I http://localhost:8000/assets/images/hero.png`


------
https://chatgpt.com/codex/tasks/task_e_68926abff668833091026af645742af6