### PR TITLE
chore: prefetch dns for external services

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -16,8 +16,13 @@
     <meta property="og:url" content="https://joshberk.github.io/blog.html" />
     <meta property="og:image" content="assets/images/preview.png" />
     <title>Blog | Joshua Offe Berkoh</title>
+    <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+    <link rel="dns-prefetch" href="//www.linkedin.com" />
+    <link rel="dns-prefetch" href="//x.com" />
+    <link rel="dns-prefetch" href="//medium.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="css/style.css" />
-        <!-- Google tag (gtag.js) -->
+    <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -16,16 +16,21 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/pivoting-cryptography.html" />
     <meta property="og:image" content="../assets/images/preview.png" />
     <title>Pivoting to Cryptography With Purpose | Joshua Offe Berkoh</title>
+    <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+    <link rel="dns-prefetch" href="//www.linkedin.com" />
+    <link rel="dns-prefetch" href="//x.com" />
+    <link rel="dns-prefetch" href="//medium.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  gtag('config', 'G-7PNPWV5C4V');
-</script>
+      gtag('config', 'G-7PNPWV5C4V');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -16,16 +16,21 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/week-1-foundational-encryption-concepts.html" />
     <meta property="og:image" content="../assets/images/preview.png" />
     <title>Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh</title>
+    <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+    <link rel="dns-prefetch" href="//www.linkedin.com" />
+    <link rel="dns-prefetch" href="//x.com" />
+    <link rel="dns-prefetch" href="//medium.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="../css/style.css" />
-   <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
-  gtag('config', 'G-7PNPWV5C4V');
-</script>
+      gtag('config', 'G-7PNPWV5C4V');
+    </script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -16,6 +16,11 @@
     <meta property="og:url" content="https://joshberk.github.io/" />
     <meta property="og:image" content="assets/images/preview.png" />
     <title>Joshua Offe Berkoh | Cryptography & Cybersecurity</title>
+    <link rel="dns-prefetch" href="//www.googletagmanager.com" />
+    <link rel="dns-prefetch" href="//www.linkedin.com" />
+    <link rel="dns-prefetch" href="//x.com" />
+    <link rel="dns-prefetch" href="//medium.com" />
+    <link rel="preconnect" href="https://www.googletagmanager.com" />
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->


### PR DESCRIPTION
## Summary
- prefetch DNS for Google Tag Manager, LinkedIn, X, and Medium across main and blog pages
- preconnect to Google Tag Manager for faster analytics loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926ac0fcac8330b12795d03169f49e