### PR TITLE
Add safe localStorage helpers for theme toggle

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -122,43 +122,39 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     };
 
-    // Track whether accessing localStorage is safe
-    let storageAvailable = true;
+    const safeGet = (key) => {
+      try {
+        return localStorage.getItem(key);
+      } catch (err) {
+        return null;
+      }
+    };
 
-    // On initial load, read the saved preference from localStorage
-    let savedTheme = null;
-    try {
-      savedTheme = localStorage.getItem('theme');
-    } catch (err) {
-      storageAvailable = false;
+    const safeSet = (key, value) => {
+      try {
+        localStorage.setItem(key, value);
+        return true;
+      } catch (err) {
+        return false;
+      }
+    };
+
+    const savedTheme = safeGet('theme');
+    if (savedTheme) {
+      applyTheme(savedTheme);
+      themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
+    } else {
       applyTheme('light');
       themeToggle.setAttribute('aria-pressed', 'false');
     }
 
-    if (storageAvailable) {
-      if (savedTheme) {
-        applyTheme(savedTheme);
-        themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
-      } else {
-        // Default to light theme if nothing saved
-        applyTheme('light');
-        themeToggle.setAttribute('aria-pressed', 'false');
-      }
-    }
-
-    // Toggle the theme when the user clicks the button
     themeToggle.addEventListener('click', () => {
       const next = themeToggle.getAttribute('aria-pressed') === 'true' ? 'light' : 'dark';
       themeToggle.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
       applyTheme(next);
-      if (storageAvailable) {
-        try {
-          localStorage.setItem('theme', next);
-        } catch (err) {
-          storageAvailable = false;
-          applyTheme('light');
-          themeToggle.setAttribute('aria-pressed', 'false');
-        }
+      if (!safeSet('theme', next)) {
+        applyTheme('light');
+        themeToggle.setAttribute('aria-pressed', 'false');
       }
     });
   }


### PR DESCRIPTION
## Summary
- add `safeGet`/`safeSet` helpers to safely access localStorage
- use helpers for theme toggle persistence and fallback to light mode if storage fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926ac1d6f883308d1d938175c9fcb6