### PR TITLE
Add Content Security Policy meta tags

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -15,6 +15,7 @@
     />
     <meta property="og:url" content="https://joshberk.github.io/blog.html" />
     <meta property="og:image" content="assets/images/preview.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
     <title>Blog | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="css/style.css" />
         <!-- Google tag (gtag.js) -->

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -15,6 +15,7 @@
     />
     <meta property="og:url" content="https://joshberk.github.io/blog/pivoting-cryptography.html" />
     <meta property="og:image" content="../assets/images/preview.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
     <title>Pivoting to Cryptography With Purpose | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -15,6 +15,7 @@
     />
     <meta property="og:url" content="https://joshberk.github.io/blog/week-1-foundational-encryption-concepts.html" />
     <meta property="og:image" content="../assets/images/preview.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
     <title>Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh</title>
     <link rel="stylesheet" href="../css/style.css" />
    <!-- Google tag (gtag.js) -->

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     />
     <meta property="og:url" content="https://joshberk.github.io/" />
     <meta property="og:image" content="assets/images/preview.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
     <title>Joshua Offe Berkoh | Cryptography & Cybersecurity</title>
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
## Summary
- add Content Security Policy meta tags to index, blog listing, and individual blog posts
- allow scripts from Google Tag Manager and Analytics while defaulting to self-origin resources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926ac3674c8330ae92a117cf9022d7