### PR TITLE
feat: tighten CSP by removing unsafe-inline

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog.html" />
 
     <meta property="og:image" content="assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="assets/images/hero.png" />
 
@@ -29,13 +29,7 @@
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-7PNPWV5C4V');
-    </script>
+    <script src="js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/pivoting-cryptography.html" />
 
     <meta property="og:image" content="../assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="../assets/images/hero.png" />
 
@@ -29,13 +29,7 @@
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-7PNPWV5C4V');
-    </script>
+    <script src="../js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/week-1-foundational-encryption-concepts.html" />
 
     <meta property="og:image" content="../assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="../assets/images/hero.png" />
 
@@ -29,13 +29,7 @@
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-7PNPWV5C4V');
-    </script>
+    <script src="../js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/" />
 
     <meta property="og:image" content="assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="assets/images/hero.png" />
 
@@ -30,13 +30,7 @@
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-7PNPWV5C4V');
-    </script>
+    <script src="js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,6 @@
+// Google Analytics configuration
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-7PNPWV5C4V');
+


### PR DESCRIPTION
## Summary
- tighten Content-Security-Policy by dropping 'unsafe-inline' and loading GA config from an external script
- move Google Analytics configuration into `js/analytics.js`

## Testing
- `npm test`
- `curl -v https://csp-evaluator.withgoogle.com/api?csp=default-src%20%27self%27%3B%20script-src%20%27self%27%20https%3A//www.googletagmanager.com%20https%3A//www.google-analytics.com%3B%20connect-src%20%27self%27%20https%3A//www.google-analytics.com%3B%20img-src%20%27self%27%20https%3A//www.google-analytics.com%3B%20style-src%20%27self%27` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68928eb9620c8330ae7475188d8e6e1b