### PR TITLE
fix: clean up blog HTML structure

### DIFF
--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -66,11 +66,10 @@
 
     <!-- Blog Post Content -->
     <article class="blog-post">
+      <h3>The Strategic Shift: Why Cryptography Now?</h3>
       <p>
-       <h3>The Strategic Shift: Why Cryptography Now?</h3>
-
-        For some time now, my doctoral work as a PhD student in Information Technology has focused on real-world systems, 
-        particularly my involvement with the Invisible Internet Project (I2P). This hands-on experience has been invaluable, 
+        For some time now, my doctoral work as a PhD student in Information Technology has focused on real-world systems,
+        particularly my involvement with the Invisible Internet Project (I2P). This hands-on experience has been invaluable,
         offering a front-row seat to the practical complexities and intricate challenges of building and maintaining secure, decentralized networks.
       </p>
       <p>
@@ -83,18 +82,16 @@
         So, this isn’t a leap into the unknown from scratch; it’s a strategic intensification of my existing academic journey. 
         I’m making a deliberate, focused shift to solidify my expertise at the very core of digital trust.
       </p>
+      <h3>My Integrated Path to Cryptographic Mastery</h3>
       <p>
-        <h3>My Integrated Path to Cryptographic Mastery</h3>
-
-        While I’m already engaged in PhD-level research, this pivot acknowledges specific areas for growth particularly refining my mathematical fluency in cryptographic 
+        While I’m already engaged in PhD-level research, this pivot acknowledges specific areas for growth particularly refining my mathematical fluency in cryptographic
         contexts and enhancing my programming for secure implementations. I believe a structured, disciplined approach will effectively bridge these areas.
       </p>
-      <p>
-        <h4>Here’s how I’m tackling this next phase of my academic and professional development:</h4>
-        <ol>
+      <h4>Here’s how I’m tackling this next phase of my academic and professional development:</h4>
+      <ol>
           <li>The Theoretical Bedrock: Embracing Mathematical Rigor</li>
-            My primary guide for this deep dive is “Introduction to Modern Cryptography” by Katz and Lindell. 
-            This book is teaching me the formal definitions, security models, and the intricate mathematical 
+            My primary guide for this deep dive is “Introduction to Modern Cryptography” by Katz and Lindell.
+            This book is teaching me the formal definitions, security models, and the intricate mathematical
             proofs (modular arithmetic, finite fields, elliptic curves) that underpin everything from symmetric encryption to digital signatures. 
             It’s about understanding not just what a primitive does, but why it’s provably secure.
 
@@ -115,18 +112,17 @@
             the design of encrypted data structures (e.g., Oblivious RAM, Structured Encryption), and the emerging challenges of cryptography for AI 
             (such as watermarking and privacy-preserving machine learning). My goal is to integrate provable security with innovative use cases, 
             leveraging my background in distributed systems from I2P.
-          </ol> 
-      </p>
-          <h3> The Commitment is Clear</h3>
-          The path to becoming an applied scientist in cryptography, especially at the PhD level, is demanding. 
-          It requires relentless learning, deep analytical thinking, and a commitment to integrating diverse skill sets. 
+          </ol>
+      <h3>The Commitment is Clear</h3>
+      <p>
+          The path to becoming an applied scientist in cryptography, especially at the PhD level, is demanding.
+          It requires relentless learning, deep analytical thinking, and a commitment to integrating diverse skill sets.
           I’m under no illusion that it’s easy, but my resolve is firm.
-          I believe the future of privacy, security, and digital trust hinges on robust, provably secure cryptography, 
-          and I’m dedicated to being part of building that future. This blog will serve as a weekly log of my structured journey, 
+          I believe the future of privacy, security, and digital trust hinges on robust, provably secure cryptography,
+          and I’m dedicated to being part of building that future. This blog will serve as a weekly log of my structured journey,
           sharing what I learn, the challenges I face, and some insights for others on similar paths.
-
-          <h2>Stay tuned for weekly updates on my progress!</h2>
       </p>
+      <h2>Stay tuned for weekly updates on my progress!</h2>
     </article>
 
     </main>

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -75,13 +75,13 @@
       all while revealing the crucial principle that ties them all together.
       </p>
       
+      <h3>Theoretical Foundations: Embracing Mathematical Rigor</h3>
       <p>
-        <h3>Theoretical Foundations: Embracing Mathematical Rigor</h3>
-      Modern cryptography rests on rigorous mathematical tools for securing digital 
-      communication against adversarial attacks. I began with <strong>symmetric (private-key) encryption</strong>, 
-      where two parties share a single key used for both encrypting and decrypting messages. 
-      Its goal? To protect the plaintext from interception as it travels across a communication channel. 
-      This is in stark contrast to <strong>asymmetric (public-key) encryption</strong>, which introduces separate keys 
+      Modern cryptography rests on rigorous mathematical tools for securing digital
+      communication against adversarial attacks. I began with <strong>symmetric (private-key) encryption</strong>,
+      where two parties share a single key used for both encrypting and decrypting messages.
+      Its goal? To protect the plaintext from interception as it travels across a communication channel.
+      This is in stark contrast to <strong>asymmetric (public-key) encryption</strong>, which introduces separate keys
       for encryption and decryption, enabling scalable systems without requiring pre-shared secrets.
       </p>
 
@@ -102,11 +102,11 @@
       
 
       
+      <h3>Applied Realities: Where Theory Meets the Real World</h3>
       <p>
-        <h3>Applied Realities: Where Theory Meets the Real World</h3>
-      The practical implications of these concepts are profound. Symmetric encryption,Symmetric encryption shines in two primary settings. 
-      The first is two-party communication, where a key is shared in advance for a secure connection. Think of a browser establishing 
-      a secure connection with a website. The second involves a single party encrypting and 
+      The practical implications of these concepts are profound. Symmetric encryption,Symmetric encryption shines in two primary settings.
+      The first is two-party communication, where a key is shared in advance for a secure connection. Think of a browser establishing
+      a secure connection with a website. The second involves a single party encrypting and
       decrypting data for itself over time, such as in <strong>disk encryption</strong>.
       </p>
       
@@ -126,25 +126,26 @@
       of key management, not the algorithm itself.
 
       </p>
-        A famous case that perfectly illustrates this is the 
-        <a href="https://en.wikipedia.org/wiki/AACS_encryption_key_controversy">HD DVD encryption key leak in 2007</a>. 
-      A single 128-bit master key was discovered and made public. The consequence was not a new, 
-      insecure algorithm, but rather that a vast number of commercially produced movies became vulnerable. 
+      <p>
+        A famous case that perfectly illustrates this is the
+        <a href="https://en.wikipedia.org/wiki/AACS_encryption_key_controversy">HD DVD encryption key leak in 2007</a>.
+      A single 128-bit master key was discovered and made public. The consequence was not a new,
+      insecure algorithm, but rather that a vast number of commercially produced movies became vulnerable.
       The inconvenience was catastrophic: replacing the key required a massive, costly overhaul of the entire industry’s encryption methods.
       </p>
-
+      
       <p>
-        <strong>This shows that it’s far easier to replace a compromised key than to replace a whole flawed encryption scheme, 
+        <strong>This shows that it’s far easier to replace a compromised key than to replace a whole flawed encryption scheme,
       which is the core foundation of Kerckhoffs’s principle.</strong>
       </p>
 
       
+      <h3>Reflections and Forward Momentum</h3>
       <p>
-        <h3>Reflections and Forward Momentum</h3>
-      The biggest revelation this week was the elegant interplay between symmetric and asymmetric encryption, 
-      and how they solve fundamentally different problems. While symmetric encryption provides the speed and 
-      efficiency needed for bulk data, asymmetric cryptography, with the invention of public-key algorithms 
-      like Diffie-Hellman, solved the long-standing problem of key distribution. Seeing the link between 
+      The biggest revelation this week was the elegant interplay between symmetric and asymmetric encryption,
+      and how they solve fundamentally different problems. While symmetric encryption provides the speed and
+      efficiency needed for bulk data, asymmetric cryptography, with the invention of public-key algorithms
+      like Diffie-Hellman, solved the long-standing problem of key distribution. Seeing the link between
       that abstract mathematical ingenuity and its application in real-world engineering has been incredibly motivating.
       </p>
 
@@ -155,13 +156,11 @@
       </p>
 
 
-      <p>
-        <h3>Study Resources</h3>
+      <h3>Study Resources</h3>
       <ul>
         <li><strong>Introduction to Modern Cryptography</strong> by Jonathan Katz and Yehuda Lindell, Chapter 1</li>
         <li><strong>Real-World Cryptography</strong> by David Wong, Chapter 1.</li>
       </ul>
-      </p>
     </article>
 
     </main>


### PR DESCRIPTION
## Summary
- restructure blog HTML so headings and lists aren't nested inside paragraphs
- ensure ordered list and study resources list are directly under their headings

## Testing
- `npm install html-validate` *(fails: 403 Forbidden)*
- `npx --yes html-validate blog/*.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68928ebdeecc8330b408dc09b0fd4c8d