### PR TITLE
Add build-time CSP nonce handling for scripts

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog.html" />
 
     <meta property="og:image" content="assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-2DkuOFQqe/g3DDOTg2/gMg==' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="assets/images/hero.png" />
 
@@ -28,8 +28,8 @@
     <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="js/analytics.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -99,6 +99,6 @@
       </p>
     </footer>
 
-    <script src="js/main.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/main.js"></script>
   </body>
 </html>

--- a/blog/pivoting-cryptography.html
+++ b/blog/pivoting-cryptography.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/pivoting-cryptography.html" />
 
     <meta property="og:image" content="../assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-2DkuOFQqe/g3DDOTg2/gMg==' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="../assets/images/hero.png" />
 
@@ -28,8 +28,8 @@
     <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="../js/analytics.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="../js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -130,6 +130,6 @@
       </p>
     </footer>
 
-    <script src="../js/main.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="../js/main.js"></script>
   </body>
 </html>

--- a/blog/week-1-foundational-encryption-concepts.html
+++ b/blog/week-1-foundational-encryption-concepts.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/week-1-foundational-encryption-concepts.html" />
 
     <meta property="og:image" content="../assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-2DkuOFQqe/g3DDOTg2/gMg==' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="../assets/images/hero.png" />
 
@@ -28,8 +28,8 @@
     <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="../css/style.css" />
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="../js/analytics.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="../js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -168,6 +168,6 @@
       </p>
     </footer>
 
-    <script src="../js/main.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="../js/main.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/" />
 
     <meta property="og:image" content="assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-2DkuOFQqe/g3DDOTg2/gMg==' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'" />
 
     <meta property="og:image" content="assets/images/hero.png" />
 
@@ -29,8 +29,8 @@
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="js/analytics.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/analytics.js"></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -358,6 +358,6 @@
     </footer>
 
     <!-- Main JavaScript -->
-    <script src="js/main.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/main.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This repository contains the source code for [Josh Berk's personal website](https://joshberk.github.io). It hosts the site's HTML, CSS, JavaScript, and related assets.",
   "main": "js/main.js",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "build": "node scripts/generateNonce.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generateNonce.js
+++ b/scripts/generateNonce.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+// Files to update with the generated nonce
+const files = [
+  'index.html',
+  'blog.html',
+  path.join('blog', 'pivoting-cryptography.html'),
+  path.join('blog', 'week-1-foundational-encryption-concepts.html')
+];
+
+// Generate a base64 nonce
+const nonce = crypto.randomBytes(16).toString('base64');
+
+files.forEach((file) => {
+  let content = fs.readFileSync(file, 'utf8');
+
+  // Update CSP meta tag
+  content = content.replace(
+    /(<meta http-equiv="Content-Security-Policy" content=")([^"]*)("\s*\/?>)/,
+    (match, start, cspContent, end) => {
+      const updated = cspContent.replace(
+        /script-src[^;]*;/,
+        `script-src 'self' 'nonce-${nonce}' https://www.googletagmanager.com https://www.google-analytics.com;`
+      );
+      return `${start}${updated}${end}`;
+    }
+  );
+
+  // Update script tags
+  content = content.replace(/<script[^>]*>/g, (tag) => {
+    if (tag.includes('nonce=')) {
+      return tag.replace(/nonce="[^"]*"/, `nonce="${nonce}"`);
+    }
+    return tag.replace('<script', `<script nonce="${nonce}"`);
+  });
+
+  fs.writeFileSync(file, content);
+  console.log(`Updated ${file}`);
+});
+
+console.log(`Generated nonce: ${nonce}`);


### PR DESCRIPTION
## Summary
- generate a base64 nonce during builds and inject it into all HTML pages and their CSP headers
- add a build step to automate nonce injection

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68929ad916d88330ad002b6ab3fdef48