### PR TITLE
feat: improve dark mode readability and focus styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,6 +33,18 @@
   --card-bg: #152341;
 }
 
+/* Respect the user's system preference when no explicit theme is set */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --primary-color: #90caf9;
+    --secondary-color: #64b5f6;
+    --accent-color: #42a5f5;
+    --background-color: #0a192f;
+    --text-color: #e5edf5;
+    --card-bg: #152341;
+  }
+}
+
 /* When the page is in dark mode and the navbar is scrolled, use a
    dark translucent background for the bar instead of the light
    background defined in the default `.navbar.scrolled` rule. This
@@ -513,6 +525,12 @@ footer a:hover {
   outline-offset: 2px;
 }
 
+/* Provide a visible focus style for keyboard navigation */
+a:focus-visible {
+  outline: 2px dashed var(--primary-color);
+  outline-offset: 2px;
+}
+
 /* Blog listing cards */
 .blog-list {
   display: grid;
@@ -533,6 +551,8 @@ footer a:hover {
   transform: translateY(-4px);
 }
 
+
+.blog-card h2,
 .blog-card h3 {
   margin-bottom: 10px;
   font-size: 1.2rem;
@@ -542,11 +562,13 @@ footer a:hover {
 /* Ensure links inside blog card headings inherit the primary colour.
  * Without this rule, anchor tags revert to the browser default
  * blue which can be hard to read on dark backgrounds. */
+.blog-card h2 a,
 .blog-card h3 a {
   color: inherit;
   text-decoration: none;
 }
 
+.blog-card h2 a:hover,
 .blog-card h3 a:hover {
   text-decoration: underline;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -114,8 +114,8 @@ document.addEventListener('DOMContentLoaded', () => {
         themeToggle.textContent = '☀️';
         themeToggle.setAttribute('aria-label', 'Switch to day mode');
       } else {
-        // Remove the attribute to fall back to the default (light) theme
-        document.documentElement.removeAttribute('data-theme');
+        // Explicitly set light theme so prefers-color-scheme can be overridden
+        document.documentElement.setAttribute('data-theme', 'light');
         // Display a moon icon to indicate a switch to dark mode is possible
         themeToggle.textContent = '🌙';
         themeToggle.setAttribute('aria-label', 'Switch to night mode');
@@ -139,14 +139,11 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     };
 
-    const savedTheme = safeGet('theme');
-    if (savedTheme) {
-      applyTheme(savedTheme);
-      themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
-    } else {
-      applyTheme('light');
-      themeToggle.setAttribute('aria-pressed', 'false');
-    }
+      const savedTheme = safeGet('theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const initialTheme = savedTheme || (prefersDark ? 'dark' : 'light');
+      applyTheme(initialTheme);
+      themeToggle.setAttribute('aria-pressed', initialTheme === 'dark' ? 'true' : 'false');
 
     themeToggle.addEventListener('click', () => {
       const next = themeToggle.getAttribute('aria-pressed') === 'true' ? 'light' : 'dark';


### PR DESCRIPTION
## Summary
- Respect user's `prefers-color-scheme` setting when no theme is stored
- Ensure blog card titles inherit the primary color for sufficient contrast
- Provide a consistent visible outline on focused links for accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f39e94688330bb63d17c30983207