### PR TITLE
feat: support category filter from query string

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -63,10 +63,16 @@
           aspiring security professionals. Select a post to dive deeper into
           each topic.
         </p>
+        <div class="category-filters">
+          <button class="category-pill active" data-category="All">All</button>
+          <button class="category-pill" data-category="Cryptography">Cryptography</button>
+          <button class="category-pill" data-category="Reflection">Reflection</button>
+          <button class="category-pill" data-category="Study Notes">Study Notes</button>
+        </div>
         <div class="blog-list">
           <!-- New blog posts sourced from the author's Medium writing. The slugs mirror
                the Medium articles and the cards include brief summaries. -->
-          <article class="blog-card">
+          <article class="blog-card" data-categories="Cryptography,Reflection">
             <h2><a href="blog/pivoting-cryptography.html">Pivoting to Cryptography With Purpose: Embracing The Rigor</a></h2>
             <span class="post-date">July 2025</span>
             <p>
@@ -75,7 +81,7 @@
               security models and a strong mathematical foundation.
             </p>
           </article>
-          <article class="blog-card">
+          <article class="blog-card" data-categories="Cryptography,Study Notes">
             <h2><a href="blog/week-1-foundational-encryption-concepts.html">Week 1: Foundational Encryption Concepts</a></h2>
             <span class="post-date">August 2025</span>
             <p>
@@ -100,5 +106,6 @@
     </footer>
 
     <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/main.js"></script>
+    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/blog.js"></script>
   </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -513,6 +513,28 @@ footer a:hover {
   outline-offset: 2px;
 }
 
+/* Blog category filter pills */
+.category-filters {
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.category-pill {
+  border: 1px solid var(--primary-color);
+  background: transparent;
+  color: var(--primary-color);
+  border-radius: 9999px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+.category-pill.active {
+  background-color: var(--primary-color);
+  color: var(--background-color);
+}
+
 /* Blog listing cards */
 .blog-list {
   display: grid;

--- a/js/blog.js
+++ b/js/blog.js
@@ -1,0 +1,48 @@
+// JavaScript for handling blog category filtering and deep linking via query params.
+// Reads the `category` parameter from the URL, activates the corresponding
+// filter pill and adjusts the page title accordingly.
+document.addEventListener('DOMContentLoaded', () => {
+  const pills = document.querySelectorAll('.category-pill');
+  const posts = document.querySelectorAll('.blog-card');
+  const baseTitle = 'Blog | Joshua Offe Berkoh';
+
+  const filterPosts = (category) => {
+    pills.forEach(pill => {
+      pill.classList.toggle('active', pill.dataset.category === category || (!category && pill.dataset.category === 'All'));
+    });
+
+    posts.forEach(post => {
+      const cats = post.dataset.categories ? post.dataset.categories.split(',').map(c => c.trim()) : [];
+      if (!category || category === 'All' || cats.includes(category)) {
+        post.style.display = '';
+      } else {
+        post.style.display = 'none';
+      }
+    });
+
+    if (category && category !== 'All') {
+      document.title = `Blog | ${category} | Joshua Offe Berkoh`;
+    } else {
+      document.title = baseTitle;
+    }
+  };
+
+  pills.forEach(pill => {
+    pill.addEventListener('click', () => {
+      const category = pill.dataset.category;
+      const params = new URLSearchParams(window.location.search);
+      if (category && category !== 'All') {
+        params.set('category', category);
+      } else {
+        params.delete('category');
+      }
+      const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+      history.replaceState(null, '', newUrl);
+      filterPosts(category);
+    });
+  });
+
+  const params = new URLSearchParams(window.location.search);
+  const initial = params.get('category') || 'All';
+  filterPosts(initial);
+});


### PR DESCRIPTION
## Summary
- support filtering blog posts by category via `?category` query string
- style and highlight active category pills
- update page title based on active category

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f3b59aac8330a75dbcef92b37b22