### PR TITLE
feat: add latest posts section

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -1,0 +1,55 @@
+/* Styles specific to the homepage */
+.latest-posts .posts-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.latest-posts .post-card {
+  background-color: var(--card-bg);
+  padding: 16px;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.latest-posts .post-category {
+  display: inline-block;
+  background-color: var(--accent-color);
+  color: #fff;
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.latest-posts .post-card h3 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+}
+
+.latest-posts .post-card h3 a {
+  color: var(--primary-color);
+  text-decoration: none;
+}
+
+.latest-posts .post-card h3 a:hover {
+  text-decoration: underline;
+}
+
+.latest-posts .post-date {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--secondary-color);
+}
+
+.latest-posts .view-all {
+  display: inline-block;
+  margin-top: 20px;
+  color: var(--secondary-color);
+  text-decoration: none;
+}
+
+.latest-posts .view-all:hover {
+  text-decoration: underline;
+}

--- a/assets/data/posts.json
+++ b/assets/data/posts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "title": "Week 1: Foundational Encryption Concepts",
+    "date": "2025-08-01",
+    "category": "Cryptography",
+    "url": "blog/week-1-foundational-encryption-concepts.html"
+  },
+  {
+    "title": "Pivoting to Cryptography With Purpose: Embracing The Rigor",
+    "date": "2025-07-01",
+    "category": "Career",
+    "url": "blog/pivoting-cryptography.html"
+  },
+  {
+    "title": "Security Innovation AppSec Cyber Range 2024 Recap",
+    "date": "2024-06-01",
+    "category": "Competition",
+    "url": "blog.html"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <link rel="preconnect" href="https://www.googletagmanager.com" />
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="assets/css/home.css" />
     <!-- Google tag (gtag.js) -->
     <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
     <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/analytics.js"></script>
@@ -305,6 +306,15 @@
             <p>Completed the 2021 Security Innovation AppSec cyber range competition, gaining early experience in application security challenges.</p>
           </div>
         </div>
+      </div>
+    </section>
+
+    <!-- Latest Posts Section -->
+    <section id="latest-posts" class="latest-posts" aria-label="Latest Posts">
+      <div class="container">
+        <h2>Latest Posts</h2>
+        <div id="latestPosts" class="posts-list"></div>
+        <a href="blog.html" class="view-all">View all &rarr;</a>
       </div>
     </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -158,4 +158,46 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  // Load latest blog posts on the homepage
+  const postsList = document.getElementById('latestPosts');
+  if (postsList) {
+    fetch('assets/data/posts.json')
+      .then((response) => response.json())
+      .then((posts) => {
+        posts
+          .sort((a, b) => new Date(b.date) - new Date(a.date))
+          .slice(0, 3)
+          .forEach((post) => {
+            const article = document.createElement('article');
+            article.className = 'post-card';
+
+            const category = document.createElement('span');
+            category.className = 'post-category';
+            category.textContent = post.category;
+            article.appendChild(category);
+
+            const title = document.createElement('h3');
+            const link = document.createElement('a');
+            link.href = post.url;
+            link.textContent = post.title;
+            title.appendChild(link);
+            article.appendChild(title);
+
+            const date = document.createElement('span');
+            date.className = 'post-date';
+            date.textContent = new Date(post.date).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric'
+            });
+            article.appendChild(date);
+
+            postsList.appendChild(article);
+          });
+      })
+      .catch(() => {
+        postsList.innerHTML = '<p>Unable to load posts at this time.</p>';
+      });
+  }
 });


### PR DESCRIPTION
## Summary
- add latest posts section on home page
- load posts dynamically from JSON and display newest three
- add minimal styling for latest posts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f3c2bf888330b332ffe3d33b11f3