### PR TITLE
Add dedicated blog stylesheet and category badges

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -1,0 +1,70 @@
+/* Styles for blog listing cards */
+.blog-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 30px;
+  margin-top: 40px;
+}
+
+.blog-card {
+  background: var(--card-bg);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  font-family: var(--font-sans);
+  color: var(--text-color);
+}
+
+.blog-card:hover,
+.blog-card:focus-within {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.08);
+  transform: translateY(-4px);
+}
+
+.blog-card:focus-within {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.blog-card h3 {
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+  color: var(--primary-color);
+}
+
+.blog-card h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.blog-card h3 a:hover,
+.blog-card h3 a:focus {
+  text-decoration: underline;
+}
+
+.blog-card .post-date {
+  font-size: 0.85rem;
+  color: var(--secondary-color);
+  margin-bottom: 10px;
+  display: block;
+}
+
+.blog-card .badge {
+  display: inline-block;
+  background: var(--secondary-color);
+  color: var(--background-color);
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  margin-bottom: 10px;
+}
+
+.blog-card p {
+  font-size: 0.95rem;
+  color: var(--text-color);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/blog.html
+++ b/blog.html
@@ -27,6 +27,7 @@
     <link rel="dns-prefetch" href="//medium.com" />
     <link rel="preconnect" href="https://www.googletagmanager.com" />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="assets/css/blog.css" />
     <!-- Google tag (gtag.js) -->
     <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
     <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/analytics.js"></script>
@@ -89,6 +90,7 @@
       function createPostCard(post) {
         const article = document.createElement('article');
         article.className = 'blog-card';
+        article.tabIndex = 0;
 
         const title = document.createElement('h3');
         const link = document.createElement('a');
@@ -100,11 +102,16 @@
         date.className = 'post-date';
         date.textContent = post.date;
 
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = post.category;
+
         const summary = document.createElement('p');
         summary.textContent = post.summary;
 
         article.appendChild(title);
         article.appendChild(date);
+        article.appendChild(badge);
         article.appendChild(summary);
 
         return article;

--- a/css/style.css
+++ b/css/style.css
@@ -513,56 +513,6 @@ footer a:hover {
   outline-offset: 2px;
 }
 
-/* Blog listing cards */
-.blog-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 30px;
-  margin-top: 40px;
-}
-
-.blog-card {
-  background-color: var(--card-bg);
-  padding: 20px;
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
-  transition: transform 0.2s ease;
-}
-
-.blog-card:hover {
-  transform: translateY(-4px);
-}
-
-.blog-card h3 {
-  margin-bottom: 10px;
-  font-size: 1.2rem;
-  color: var(--primary-color);
-}
-
-/* Ensure links inside blog card headings inherit the primary colour.
- * Without this rule, anchor tags revert to the browser default
- * blue which can be hard to read on dark backgrounds. */
-.blog-card h3 a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.blog-card h3 a:hover {
-  text-decoration: underline;
-}
-
-.blog-card .post-date {
-  font-size: 0.85rem;
-  color: var(--secondary-color);
-  margin-bottom: 10px;
-  display: block;
-}
-
-.blog-card p {
-  font-size: 0.95rem;
-  color: var(--text-color);
-}
-
 /* Category filter pills */
 .category-filter {
   margin-top: 20px;


### PR DESCRIPTION
## Summary
- style blog listings in new `assets/css/blog.css`
- add category badges and accessible cards in `blog.html`
- remove legacy blog-card rules from main stylesheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689620ad12008330a0e889e5557fc6ab