### PR TITLE
Align blog post categories with filter labels

### DIFF
--- a/assets/data/posts.json
+++ b/assets/data/posts.json
@@ -17,21 +17,21 @@
     "title": "OSINT Techniques for Modern Investigations",
     "date": "March 2024",
     "summary": "Practical open source intelligence workflows for uncovering digital footprints and tracing malicious actors.",
-    "category": "Open Source Intelligence",
+    "category": "OSINT",
     "url": "#"
   },
   {
     "title": "Reverse Engineering a Botnet Sample",
     "date": "November 2023",
     "summary": "A walkthrough of dissecting a simple malware specimen to reveal its command-and-control logic.",
-    "category": "Malware Reverse Engineering",
+    "category": "Reverse Engineering",
     "url": "#"
   },
   {
     "title": "Building a Secure Home Lab on a Budget",
     "date": "May 2022",
     "summary": "Tips for assembling a cost-effective lab environment for cybersecurity experiments.",
-    "category": "Others",
+    "category": "Malware",
     "url": "#"
   }
 ]

--- a/blog.html
+++ b/blog.html
@@ -65,9 +65,9 @@
           <div class="category-filter" role="group" aria-label="Filter posts by category">
             <button type="button" data-category="All" aria-pressed="true">All</button>
             <button type="button" data-category="Cryptography" aria-pressed="false">Cryptography</button>
-            <button type="button" data-category="Open Source Intelligence" aria-pressed="false">Open Source Intelligence</button>
-            <button type="button" data-category="Malware Reverse Engineering" aria-pressed="false">Malware Reverse Engineering</button>
-            <button type="button" data-category="Others" aria-pressed="false">Others</button>
+            <button type="button" data-category="OSINT" aria-pressed="false">OSINT</button>
+            <button type="button" data-category="Malware" aria-pressed="false">Malware</button>
+            <button type="button" data-category="Reverse Engineering" aria-pressed="false">Reverse Engineering</button>
           </div>
           <div id="posts"></div>
 
@@ -125,7 +125,7 @@
       function renderPosts(category) {
         postsContainer.innerHTML = '';
         if (category === 'All') {
-          const categories = ['Cryptography','Open Source Intelligence','Malware Reverse Engineering','Others'];
+            const categories = ['Cryptography','OSINT','Malware','Reverse Engineering'];
           categories.forEach(cat => {
             const group = postsData.filter(p => p.category === cat);
             if (group.length) {


### PR DESCRIPTION
## Summary
- Update posts data so each entry uses one of four blog categories: Cryptography, OSINT, Malware, or Reverse Engineering
- Revise blog page filters and rendering logic to use the same category labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68962c71d7c4833088d195aad8ad397b