### PR TITLE
Add card-based blog category filter with deep-linking

### DIFF
--- a/assets/css/blog.css
+++ b/assets/css/blog.css
@@ -90,7 +90,8 @@
 }
 
 .category-card:hover,
-.category-card:focus {
+.category-card:focus,
+.category-card.active {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.08);
   transform: translateY(-4px);
 }

--- a/assets/data/posts.json
+++ b/assets/data/posts.json
@@ -17,7 +17,7 @@
     "title": "OSINT Techniques for Modern Investigations",
     "date": "March 2024",
     "summary": "Practical open source intelligence workflows for uncovering digital footprints and tracing malicious actors.",
-    "category": "OSINT",
+    "category": "Open Source Intelligence",
     "url": "#"
   },
   {

--- a/blog.html
+++ b/blog.html
@@ -63,28 +63,13 @@
             Select a post to dive deeper into each topic.
           </p>
 
-          <div class="category-filter" role="group" aria-label="Filter posts by category">
-
-            <button type="button" class="category-card" data-category="All" aria-pressed="true">All</button>
-            <button type="button" class="category-card" data-category="Cryptography" aria-pressed="false">Cryptography</button>
-            <button type="button" class="category-card" data-category="Open Source Intelligence" aria-pressed="false">Open Source Intelligence</button>
-            <button type="button" class="category-card" data-category="Malware Reverse Engineering" aria-pressed="false">Malware Reverse Engineering</button>
-            <button type="button" class="category-card" data-category="Others" aria-pressed="false">Others</button>
-
-            <button type="button" data-category="All" aria-pressed="true">All</button>
-            <button type="button" data-category="Cryptography" aria-pressed="false">Cryptography</button>
-            <button type="button" data-category="OSINT" aria-pressed="false">OSINT</button>
-            <button type="button" data-category="Malware" aria-pressed="false">Malware</button>
-            <button type="button" data-category="Reverse Engineering" aria-pressed="false">Reverse Engineering</button>
-
           <div class="category-filter" aria-label="Filter posts by category">
             <a class="category-card" data-category="Cryptography" href="blog.html?category=Cryptography">Cryptography</a>
             <a class="category-card" data-category="Open Source Intelligence" href="blog.html?category=Open%20Source%20Intelligence">Open Source Intelligence</a>
             <a class="category-card" data-category="Malware" href="blog.html?category=Malware">Malware</a>
             <a class="category-card" data-category="Reverse Engineering" href="blog.html?category=Reverse%20Engineering">Reverse Engineering</a>
-
-
           </div>
+
           <div id="posts"></div>
 
         </div>
@@ -101,132 +86,6 @@
     </footer>
 
     <script nonce="2DkuOFQqe/g3DDOTg2/gMg==" src="js/main.js"></script>
-
     <script src="js/blog.js"></script>
-
-
-
-    <script nonce="2DkuOFQqe/g3DDOTg2/gMg==">
-      const filterContainer = document.querySelector('.category-filter');
-      const postsContainer = document.getElementById('posts');
-      let postsData = [];
-
-      function createPostCard(post) {
-        const article = document.createElement('article');
-        article.className = 'blog-card';
-        article.tabIndex = 0;
-
-        const title = document.createElement('h3');
-        const link = document.createElement('a');
-        link.href = post.url;
-        link.textContent = post.title;
-        title.appendChild(link);
-
-        const date = document.createElement('span');
-        date.className = 'post-date';
-        date.textContent = post.date;
-
-        const badge = document.createElement('span');
-        badge.className = 'badge';
-        badge.textContent = post.category;
-
-        const summary = document.createElement('p');
-        summary.textContent = post.summary;
-
-        article.appendChild(title);
-        article.appendChild(date);
-        article.appendChild(badge);
-        article.appendChild(summary);
-
-        return article;
-      }
-
-      function renderPosts(category) {
-        postsContainer.innerHTML = '';
-
-        if (category === 'All') {
-            const categories = ['Cryptography','OSINT','Malware','Reverse Engineering'];
-
-        if (!category) {
-          const categories = [...new Set(postsData.map(p => p.category))];
-
-          categories.forEach(cat => {
-            const group = postsData.filter(p => p.category === cat);
-            if (group.length) {
-              const section = document.createElement('section');
-              section.className = 'category-section';
-
-              const heading = document.createElement('h2');
-              heading.textContent = cat;
-              section.appendChild(heading);
-
-              const list = document.createElement('div');
-              list.className = 'blog-list';
-              group.forEach(post => list.appendChild(createPostCard(post)));
-              section.appendChild(list);
-
-              postsContainer.appendChild(section);
-            }
-          });
-        } else {
-          const group = postsData.filter(p => p.category === category);
-          const section = document.createElement('section');
-          section.className = 'category-section';
-
-          const heading = document.createElement('h2');
-          heading.textContent = category;
-          section.appendChild(heading);
-
-          if (group.length) {
-            const list = document.createElement('div');
-            list.className = 'blog-list';
-            group.forEach(post => list.appendChild(createPostCard(post)));
-            section.appendChild(list);
-          } else {
-            const msg = document.createElement('p');
-            msg.textContent = 'No posts available.';
-            section.appendChild(msg);
-          }
-
-          postsContainer.appendChild(section);
-        }
-      }
-
-      function setActiveCard(category) {
-        filterContainer.querySelectorAll('.category-card').forEach(card => {
-          card.classList.toggle('active', card.dataset.category === category);
-        });
-      }
-
-      filterContainer.addEventListener('click', (e) => {
-        const card = e.target.closest('.category-card');
-        if (card) {
-          e.preventDefault();
-          const selected = card.dataset.category;
-          const params = new URLSearchParams(window.location.search);
-          if (selected) {
-            params.set('category', selected);
-          } else {
-            params.delete('category');
-          }
-          const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
-          history.replaceState(null, '', newUrl);
-          setActiveCard(selected);
-          renderPosts(selected);
-        }
-      });
-
-      fetch('assets/data/posts.json')
-        .then(res => res.json())
-        .then(data => {
-          postsData = data;
-          const params = new URLSearchParams(window.location.search);
-          const initial = params.get('category');
-          setActiveCard(initial);
-          renderPosts(initial);
-        });
-    </script>
-
-
   </body>
 </html>

--- a/js/blog.js
+++ b/js/blog.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const filterCards = document.querySelectorAll('.category-card');
+  const filterContainer = document.querySelector('.category-filter');
+  const cards = document.querySelectorAll('.category-card');
   const postsContainer = document.getElementById('posts');
   let postsData = [];
 
@@ -35,8 +36,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderPosts(category) {
     postsContainer.innerHTML = '';
-    if (category === 'All') {
-      const categories = ['Cryptography', 'Open Source Intelligence', 'Malware Reverse Engineering', 'Others'];
+    if (!category) {
+      const categories = [...new Set(postsData.map(p => p.category))];
       categories.forEach(cat => {
         const group = postsData.filter(p => p.category === cat);
         if (group.length) {
@@ -79,20 +80,33 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  filterCards.forEach(card => {
-    card.addEventListener('click', () => {
-      const selected = card.dataset.category;
-      filterCards.forEach(btn => btn.setAttribute('aria-pressed', 'false'));
-      card.setAttribute('aria-pressed', 'true');
-      renderPosts(selected);
+  function setActiveCard(category) {
+    cards.forEach(card => {
+      card.classList.toggle('active', card.dataset.category === category);
     });
+  }
+
+  filterContainer.addEventListener('click', e => {
+    const card = e.target.closest('.category-card');
+    if (!card) return;
+    e.preventDefault();
+    const selected = card.dataset.category;
+    const params = new URLSearchParams(window.location.search);
+    params.set('category', selected);
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    history.replaceState(null, '', newUrl);
+    setActiveCard(selected);
+    renderPosts(selected);
   });
 
   fetch('assets/data/posts.json')
     .then(res => res.json())
     .then(data => {
       postsData = data;
-      renderPosts('All');
+      const params = new URLSearchParams(window.location.search);
+      const initial = params.get('category');
+      setActiveCard(initial);
+      renderPosts(initial);
     });
 });
 


### PR DESCRIPTION
## Summary
- replace blog category buttons with card links that navigate via query parameters
- style new category cards and active states
- load and filter posts based on the URL `category` parameter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896316c1c388330b7ee4809c60690be