### PR TITLE
fix: restore About section read more toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -271,15 +271,17 @@ button.hamburger {
 }
 
 /* Expandable About section */
-.about-expandable {
+.about-expandable[hidden] {
   display: none;
+}
+
+.about-expandable {
   opacity: 0;
   transform: translateY(-10px);
   transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
 .about-expandable.expanded {
-  display: block;
   opacity: 1;
   transform: translateY(0);
   animation: slideIn 0.4s cubic-bezier(0.4, 0, 0.2, 1);

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
               are industry ready.
             </p>
             
-            <div class="about-expandable" id="about-expandable">
+            <div class="about-expandable" id="about-expandable" hidden>
               <p>
                 Professionally, I've built experience across academia, industry, and high stakes security environments. As a Security Engineer Intern at Intuit Inc.,
                 As an Adjunct Instructor at the University of Cincinnati, I redesigned and delivered undergraduate curricula in IT fundamentals, introducing hands-on labs 

--- a/js/main.js
+++ b/js/main.js
@@ -31,13 +31,15 @@ const initializeAboutExpander = () => {
 
   const toggleExpansion = () => {
     isExpanded = !isExpanded;
-    
+
     if (isExpanded) {
+      expandableContent.hidden = false;
       expandableContent.classList.add('expanded');
       toggleText.textContent = 'Read Less';
       toggleIcon.textContent = '▲';
       toggleButton.setAttribute('aria-expanded', 'true');
     } else {
+      expandableContent.hidden = true;
       expandableContent.classList.remove('expanded');
       toggleText.textContent = 'Read More';
       toggleIcon.textContent = '▼';
@@ -48,6 +50,7 @@ const initializeAboutExpander = () => {
   toggleButton.addEventListener('click', toggleExpansion);
   toggleButton.setAttribute('aria-expanded', 'false');
   toggleButton.setAttribute('aria-controls', 'about-expandable');
+  expandableContent.hidden = true;
 };
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Hide about section details using the `hidden` attribute
- Toggle visibility and accessibility state for `Read More` button
- Apply CSS rule for hidden expandable area

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68989742959483308afe0baa05a69170