### PR TITLE
Open resume PDF in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
           secure systems and exploring the frontiers of cybersecurity.
         </p>
         <a href="#about" class="btn btn-primary">Learn More</a>
-        <a href="assets/resume.pdf" class="btn btn-outline" download>Download CV</a>
+        <a href="assets/resume.pdf" class="btn btn-outline" target="_blank" rel="noopener noreferrer">View CV</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- open resume link in new tab and allow browser to render PDF instead of forcing download

## Testing
- `npm test`
- `curl -I http://localhost:8000/assets/resume.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6898998bb5288330aa8446fe742bda03