### PR TITLE
Defer main script for earlier execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,6 +378,6 @@
     </footer>
 
     <!-- Main JavaScript -->
-    <script src="js/main.js"></script>
+    <script src="js/main.js" defer></script>
   </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -21,12 +21,12 @@ const insertCurrentYear = () => {
 const initializeAboutExpander = () => {
   const expandableContent = document.getElementById('about-expandable');
   const toggleButton = document.getElementById('read-more-btn');
-  
+
   if (!expandableContent || !toggleButton) return;
 
   const toggleText = toggleButton.querySelector('.read-more-text');
   const toggleIcon = toggleButton.querySelector('.read-more-icon');
-  
+
   let isExpanded = false;
 
   const toggleExpansion = () => {
@@ -53,155 +53,154 @@ const initializeAboutExpander = () => {
   expandableContent.hidden = true;
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  const navbar = document.querySelector('.navbar');
-  const navMenu = document.querySelector('.navbar ul');
-  // Select only navigation links within the menu list, excluding brand links
-  const navLinks = document.querySelectorAll('.navbar ul li a');
-  const hamburger = document.querySelector('.hamburger');
-  const sections = document.querySelectorAll('main section');
+const navbar = document.querySelector('.navbar');
+const navMenu = document.querySelector('.navbar ul');
+// Select only navigation links within the menu list, excluding brand links
+const navLinks = document.querySelectorAll('.navbar ul li a');
+const hamburger = document.querySelector('.hamburger');
+const sections = document.querySelectorAll('main section');
 
-  // Mark the top section as active on initial load
-  const heroLink = document.querySelector('.navbar a[href="#hero"]');
-  if (heroLink && document.getElementById('hero')) {
-    heroLink.classList.add('active');
+// Mark the top section as active on initial load
+const heroLink = document.querySelector('.navbar a[href="#hero"]');
+if (heroLink && document.getElementById('hero')) {
+  heroLink.classList.add('active');
+}
+
+insertCurrentYear();
+
+// Render latest blog posts if container exists
+if (typeof renderLatestPosts === 'function') {
+  renderLatestPosts();
+}
+
+// Initialize expandable About section
+initializeAboutExpander();
+
+// Add background and shadow when scrolled beyond a certain amount
+window.addEventListener('scroll', () => {
+  if (window.scrollY > 80) {
+    navbar.classList.add('scrolled');
+  } else {
+    navbar.classList.remove('scrolled');
   }
+});
 
-  insertCurrentYear();
-  
-  // Render latest blog posts if container exists
-  if (typeof renderLatestPosts === 'function') {
-    renderLatestPosts();
-  }
+if (hamburger && navMenu) {
+  // Ensure the button points to the navigation menu for accessibility
+  hamburger.setAttribute('aria-controls', navMenu.id);
 
-  // Initialize expandable About section
-  initializeAboutExpander();
-
-  // Add background and shadow when scrolled beyond a certain amount
-  window.addEventListener('scroll', () => {
-    if (window.scrollY > 80) {
-      navbar.classList.add('scrolled');
-    } else {
-      navbar.classList.remove('scrolled');
-    }
+  // Toggle the mobile navigation menu
+  hamburger.addEventListener('click', () => {
+    const expanded = hamburger.getAttribute('aria-expanded') === 'true';
+    hamburger.setAttribute('aria-expanded', (!expanded).toString());
+    navMenu.classList.toggle('open');
+    hamburger.classList.toggle('open');
   });
 
-  if (hamburger && navMenu) {
-    // Ensure the button points to the navigation menu for accessibility
-    hamburger.setAttribute('aria-controls', navMenu.id);
-
-    // Toggle the mobile navigation menu
-    hamburger.addEventListener('click', () => {
-      const expanded = hamburger.getAttribute('aria-expanded') === 'true';
-      hamburger.setAttribute('aria-expanded', (!expanded).toString());
-      navMenu.classList.toggle('open');
-      hamburger.classList.toggle('open');
+  // Close the mobile menu when a link is clicked
+  navLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      if (navMenu.classList.contains('open')) {
+        navMenu.classList.remove('open');
+        hamburger.classList.remove('open');
+        hamburger.setAttribute('aria-expanded', 'false');
+      }
     });
+  });
+}
 
-    // Close the mobile menu when a link is clicked
-    navLinks.forEach(link => {
-      link.addEventListener('click', () => {
-        if (navMenu.classList.contains('open')) {
-          navMenu.classList.remove('open');
-          hamburger.classList.remove('open');
-          hamburger.setAttribute('aria-expanded', 'false');
+// IntersectionObserver to highlight the active navigation link
+const observerOptions = {
+  root: null,
+  rootMargin: '-50% 0px -50% 0px',
+  threshold: 0
+};
+
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      navLinks.forEach(link => {
+        link.classList.remove('active');
+        const targetId = link.getAttribute('href').substring(1);
+        if (targetId === entry.target.id) {
+          link.classList.add('active');
         }
       });
-    });
-  }
+    }
+  });
+}, observerOptions);
 
-  // IntersectionObserver to highlight the active navigation link
-  const observerOptions = {
-    root: null,
-    rootMargin: '-50% 0px -50% 0px',
-    threshold: 0
+sections.forEach(section => {
+  observer.observe(section);
+});
+
+// --------------------------------------------------
+// Theme Toggle Functionality
+//
+// Allow visitors to switch between light and dark modes. The
+// interface uses a simple button in the navigation bar. When
+// clicked, the button toggles the `data-theme` attribute on the
+// document element, updates its own icon and accessible label, and
+// persists the choice in localStorage so it remains consistent
+// across page loads.
+const themeToggle = document.getElementById('themeToggle');
+if (themeToggle) {
+  /**
+   * Apply the requested theme to the document and adjust the
+   * toggle button accordingly.
+   *
+   * @param {string} theme Either 'light' or 'dark'
+   */
+  const applyTheme = (theme) => {
+    if (theme === 'dark') {
+      // Set a data attribute so CSS selectors can apply dark variables
+      document.documentElement.setAttribute('data-theme', 'dark');
+      // Display a sun icon to indicate a return to light mode is possible
+      themeToggle.textContent = '☀️';
+      themeToggle.setAttribute('aria-label', 'Switch to day mode');
+    } else {
+      // Remove the attribute to fall back to the default (light) theme
+      document.documentElement.removeAttribute('data-theme');
+      // Display a moon icon to indicate a switch to dark mode is possible
+      themeToggle.textContent = '🌙';
+      themeToggle.setAttribute('aria-label', 'Switch to night mode');
+    }
   };
 
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        navLinks.forEach(link => {
-          link.classList.remove('active');
-          const targetId = link.getAttribute('href').substring(1);
-          if (targetId === entry.target.id) {
-            link.classList.add('active');
-          }
-        });
-      }
-    });
-  }, observerOptions);
+  const safeGet = (key) => {
+    try {
+      return localStorage.getItem(key);
+    } catch (err) {
+      return null;
+    }
+  };
 
-  sections.forEach(section => {
-    observer.observe(section);
-  });
+  const safeSet = (key, value) => {
+    try {
+      localStorage.setItem(key, value);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  };
 
-  // --------------------------------------------------
-  // Theme Toggle Functionality
-  //
-  // Allow visitors to switch between light and dark modes. The
-  // interface uses a simple button in the navigation bar. When
-  // clicked, the button toggles the `data-theme` attribute on the
-  // document element, updates its own icon and accessible label, and
-  // persists the choice in localStorage so it remains consistent
-  // across page loads.
-  const themeToggle = document.getElementById('themeToggle');
-  if (themeToggle) {
-    /**
-     * Apply the requested theme to the document and adjust the
-     * toggle button accordingly.
-     *
-     * @param {string} theme Either 'light' or 'dark'
-     */
-    const applyTheme = (theme) => {
-      if (theme === 'dark') {
-        // Set a data attribute so CSS selectors can apply dark variables
-        document.documentElement.setAttribute('data-theme', 'dark');
-        // Display a sun icon to indicate a return to light mode is possible
-        themeToggle.textContent = '☀️';
-        themeToggle.setAttribute('aria-label', 'Switch to day mode');
-      } else {
-        // Remove the attribute to fall back to the default (light) theme
-        document.documentElement.removeAttribute('data-theme');
-        // Display a moon icon to indicate a switch to dark mode is possible
-        themeToggle.textContent = '🌙';
-        themeToggle.setAttribute('aria-label', 'Switch to night mode');
-      }
-    };
+  const savedTheme = safeGet('theme');
+  if (savedTheme) {
+    applyTheme(savedTheme);
+    themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
+  } else {
+    applyTheme('light');
+    themeToggle.setAttribute('aria-pressed', 'false');
+  }
 
-    const safeGet = (key) => {
-      try {
-        return localStorage.getItem(key);
-      } catch (err) {
-        return null;
-      }
-    };
-
-    const safeSet = (key, value) => {
-      try {
-        localStorage.setItem(key, value);
-        return true;
-      } catch (err) {
-        return false;
-      }
-    };
-
-    const savedTheme = safeGet('theme');
-    if (savedTheme) {
-      applyTheme(savedTheme);
-      themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
-    } else {
+  themeToggle.addEventListener('click', () => {
+    const next = themeToggle.getAttribute('aria-pressed') === 'true' ? 'light' : 'dark';
+    themeToggle.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
+    applyTheme(next);
+    if (!safeSet('theme', next)) {
       applyTheme('light');
       themeToggle.setAttribute('aria-pressed', 'false');
     }
+  });
+}
 
-    themeToggle.addEventListener('click', () => {
-      const next = themeToggle.getAttribute('aria-pressed') === 'true' ? 'light' : 'dark';
-      themeToggle.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
-      applyTheme(next);
-      if (!safeSet('theme', next)) {
-        applyTheme('light');
-        themeToggle.setAttribute('aria-pressed', 'false');
-      }
-    });
-  }
-});


### PR DESCRIPTION
## Summary
- Load the site's JavaScript with `defer` so it runs after DOM parsing.
- Remove the `DOMContentLoaded` wrapper and execute initialization code directly.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898a39609008330b139ce1562d28dc3