### PR TITLE
Add touchstart listener for About expander

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -48,6 +48,7 @@ const initializeAboutExpander = () => {
   };
 
   toggleButton.addEventListener('click', toggleExpansion);
+  toggleButton.addEventListener('touchstart', toggleExpansion);
   toggleButton.setAttribute('aria-expanded', 'false');
   toggleButton.setAttribute('aria-controls', 'about-expandable');
   expandableContent.hidden = true;


### PR DESCRIPTION
## Summary
- ensure About section expander responds to touch by binding touchstart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a3984e3883308e275d2561681043