### PR TITLE
Clean up theme toggle implementation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -93,7 +93,6 @@ if (hamburger && navMenu) {
   // Ensure the button points to the navigation menu for accessibility
   hamburger.setAttribute('aria-controls', navMenu.id);
 
-
   // Add background and shadow when scrolled beyond a certain amount
   window.addEventListener('scroll', function () {
     if (window.scrollY > 80) {
@@ -102,17 +101,6 @@ if (hamburger && navMenu) {
       navbar.classList.remove('scrolled');
     }
   });
-
-  if (hamburger && navMenu) {
-    // Ensure the button points to the navigation menu for accessibility
-    hamburger.setAttribute('aria-controls', navMenu.id);
-
-    // Toggle the mobile navigation menu
-    hamburger.addEventListener('click', function () {
-      const expanded = hamburger.getAttribute('aria-expanded') === 'true';
-      hamburger.setAttribute('aria-expanded', (!expanded).toString());
-      navMenu.classList.toggle('open');
-      hamburger.classList.toggle('open');
 
   // Toggle the mobile navigation menu
   hamburger.addEventListener('click', () => {
@@ -130,19 +118,9 @@ if (hamburger && navMenu) {
         hamburger.classList.remove('open');
         hamburger.setAttribute('aria-expanded', 'false');
       }
-
     });
   });
 }
-
-
-    // Close the mobile menu when a link is clicked
-    navLinks.forEach(function (link) {
-      link.addEventListener('click', function () {
-        if (navMenu.classList.contains('open')) {
-          navMenu.classList.remove('open');
-          hamburger.classList.remove('open');
-          hamburger.setAttribute('aria-expanded', 'false');
 
 // IntersectionObserver to highlight the active navigation link
 const observerOptions = {
@@ -189,61 +167,10 @@ const observer = new IntersectionObserver((entries) => {
       });
     }, observerOptions);
 
-    sections.forEach(function (section) {
-      observer.observe(section);
-    });
-  }
-
-  // --------------------------------------------------
-  // Theme Toggle Functionality
-  //
-  // Allow visitors to switch between light and dark modes. The
-  // interface uses a simple button in the navigation bar. When
-  // clicked, the button toggles the `data-theme` attribute on the
-  // document element, updates its own icon and accessible label, and
-  // persists the choice in localStorage so it remains consistent
-  // across page loads.
-  const themeToggle = document.getElementById('themeToggle');
-  if (themeToggle) {
-    /**
-     * Apply the requested theme to the document and adjust the
-     * toggle button accordingly.
-     *
-     * @param {string} theme Either 'light' or 'dark'
-     */
-    function applyTheme(theme) {
-      if (theme === 'dark') {
-        // Set a data attribute so CSS selectors can apply dark variables
-        document.documentElement.setAttribute('data-theme', 'dark');
-        // Display a sun icon to indicate a return to light mode is possible
-        themeToggle.textContent = '☀️';
-        themeToggle.setAttribute('aria-label', 'Switch to day mode');
-      } else {
-        // Remove the attribute to fall back to the default (light) theme
-        document.documentElement.removeAttribute('data-theme');
-        // Display a moon icon to indicate a switch to dark mode is possible
-        themeToggle.textContent = '🌙';
-        themeToggle.setAttribute('aria-label', 'Switch to night mode');
-      }
-    }
-
-    function safeGet(key) {
-      try {
-        return localStorage.getItem(key);
-      } catch (err) {
-        return null;
-      }
-    }
-
-    function safeSet(key, value) {
-      try {
-        localStorage.setItem(key, value);
-        return true;
-      } catch (err) {
-        return false;
-      }
-    }
-
+sections.forEach(function (section) {
+  observer.observe(section);
+});
+}
 sections.forEach(section => {
   observer.observe(section);
 });
@@ -319,16 +246,5 @@ if (themeToggle) {
   });
 }
 
-
-    themeToggle.addEventListener('click', function () {
-      const next = themeToggle.getAttribute('aria-pressed') === 'true' ? 'light' : 'dark';
-      themeToggle.setAttribute('aria-pressed', next === 'dark' ? 'true' : 'false');
-      applyTheme(next);
-      if (!safeSet('theme', next)) {
-        applyTheme('light');
-        themeToggle.setAttribute('aria-pressed', 'false');
-      }
-    });
-  }
 });
 


### PR DESCRIPTION
## Summary
- remove redundant theme toggle code and keep a single implementation
- drop extra click listener so theme logic only runs when the toggle exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a8517e408330a04d124b2d1c963d