### PR TITLE
Remove duplicate blog main.js inclusion

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -27,7 +27,6 @@
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="js/main.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts="></script>
   </head>
   <body>
     <!-- Navigation Bar -->


### PR DESCRIPTION
## Summary
- Remove redundant `js/main.js` include from blog head
- Keep deferred footer script for better performance

## Testing
- `npm test`
- `npx --yes --package jsdom node - <<'NODE'
const { JSDOM } = require('jsdom');
JSDOM.fromFile('blog.html', { runScripts: 'dangerously', resources: 'usable', url: 'https://example.com/' }).then(dom => {
  dom.window.addEventListener('DOMContentLoaded', () => {
    console.log('DOMContentLoaded');
  });
  dom.window.addEventListener('load', () => {
    console.log('Load event');
    // some sanity check
    const year = dom.window.document.getElementById('year');
    console.log('Year element exists:', !!year);
    const postsScript = dom.window.renderLatestPosts ? 'yes' : 'no';
    console.log('renderLatestPosts defined:', postsScript);
    setTimeout(() => {
      console.log('Nav menu items:', dom.window.document.querySelectorAll('#nav-menu li').length);
      process.exit(0);
    }, 0);
  });
}).catch(err => { console.error(err); process.exit(1); });
NODE` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c89bc8ef08330b45ab4f4b5ad43b2