### PR TITLE
Refactor post count updates and add tests

### DIFF
--- a/js/blogPosts.js
+++ b/js/blogPosts.js
@@ -47,25 +47,24 @@ function getPostCountByDiscipline(discipline) {
 }
 
 function updatePostCounts() {
-  const disciplines = {
+  const counts = {
     'Cryptography': getPostCountByDiscipline('Cryptography'),
     'Malware Reverse Engineering': getPostCountByDiscipline('Malware Reverse Engineering'),
     'OSINT': getPostCountByDiscipline('OSINT'),
     'Others': getPostCountByDiscipline('Others')
   };
 
-  Object.keys(disciplines).forEach(function(discipline) {
-    const cards = document.querySelectorAll('.discipline-card');
-    cards.forEach(function(card) {
-      const title = card.querySelector('h3');
-      if (title && title.textContent.trim() === discipline) {
-        const countElement = card.querySelector('.post-count');
-        const count = disciplines[discipline];
-        if (countElement) {
-          countElement.textContent = count > 0 ? count + ' post' + (count === 1 ? '' : 's') : 'Coming soon';
-        }
-      }
-    });
+  const cards = document.querySelectorAll('.discipline-card');
+  cards.forEach(function(card) {
+    const title = card.querySelector('h3');
+    if (!title) return;
+
+    const discipline = title.textContent.trim();
+    const countElement = card.querySelector('.post-count');
+    if (!countElement) return;
+
+    const count = counts[discipline] || 0;
+    countElement.textContent = count > 0 ? count + ' post' + (count === 1 ? '' : 's') : 'Coming soon';
   });
 }
 
@@ -93,4 +92,9 @@ function renderLatestPosts() {
       </article>
     `;
   }).join('');
+}
+
+// Exports for testing in Node environments
+if (typeof module !== 'undefined') {
+  module.exports = { blogPosts, getPostCountByDiscipline, updatePostCounts };
 }

--- a/test/postCounts.test.js
+++ b/test/postCounts.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { updatePostCounts, blogPosts } = require('../js/blogPosts.js');
+
+test('updatePostCounts sets correct text for each discipline card', () => {
+  const counts = {
+    Cryptography: blogPosts.filter(p => p.discipline === 'Cryptography').length,
+    'Malware Reverse Engineering': 0,
+    OSINT: 0,
+    Others: 0
+  };
+
+  function makeCard(title) {
+    const h3 = { textContent: title };
+    const countElement = { textContent: '' };
+    return {
+      querySelector(selector) {
+        if (selector === 'h3') return h3;
+        if (selector === '.post-count') return countElement;
+        return null;
+      }
+    };
+  }
+
+  const cards = [
+    makeCard('Cryptography'),
+    makeCard('Malware Reverse Engineering'),
+    makeCard('OSINT'),
+    makeCard('Others')
+  ];
+
+  global.document = {
+    querySelectorAll() {
+      return cards;
+    }
+  };
+
+  updatePostCounts();
+
+  assert.equal(cards[0].querySelector('.post-count').textContent, `${counts.Cryptography} posts`);
+  assert.equal(cards[1].querySelector('.post-count').textContent, 'Coming soon');
+  assert.equal(cards[2].querySelector('.post-count').textContent, 'Coming soon');
+  assert.equal(cards[3].querySelector('.post-count').textContent, 'Coming soon');
+
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- cache discipline cards and update counts from a lookup map
- export blog helper functions for testing
- add unit test ensuring each discipline card renders correct post counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c89b901b88330906508636e1a4b24