### PR TITLE
Use improved nonce generator

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog.html" />
 
     <meta property="og:image" content="assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
 
     <title>Blog | Joshua Offe Berkoh</title>
     <link rel="dns-prefetch" href="//www.googletagmanager.com" />
@@ -27,7 +27,7 @@
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="js/main.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts="></script>
+    <script src="js/main.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -125,7 +125,7 @@
       </p>
     </footer>
 
-    <script src="js/blogPosts.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts="></script>
-    <script src="js/main.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts="></script>
+    <script src="js/blogPosts.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
+    <script src="js/main.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </body>
 </html>

--- a/blog/cryptography/pivoting-cryptography.html
+++ b/blog/cryptography/pivoting-cryptography.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/cryptography/pivoting-cryptography.html" />
 
     <meta property="og:image" content="../../assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
 
 
     <title>Pivoting to Cryptography With Purpose | Joshua Offe Berkoh</title>
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="../../css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="../../js/analytics.js"></script>
+    <script src="../../js/analytics.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -133,6 +133,6 @@
       </p>
     </footer>
 
-    <script src="../../js/main.js"></script>
+    <script src="../../js/main.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </body>
 </html>

--- a/blog/cryptography/week-1-foundational-encryption-concepts.html
+++ b/blog/cryptography/week-1-foundational-encryption-concepts.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/blog/cryptography/week-1-foundational-encryption-concepts.html" />
 
     <meta property="og:image" content="../../assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
 
 
     <title>Week 1: Foundational Encryption Concepts | Joshua Offe Berkoh</title>
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="../../css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="../../js/analytics.js"></script>
+    <script src="../../js/analytics.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -167,6 +167,6 @@
       </p>
     </footer>
 
-    <script src="../../js/main.js"></script>
+    <script src="../../js/main.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://joshberk.github.io/" />
 
     <meta property="og:image" content="assets/images/preview.png" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk=' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com; style-src 'self'; object-src 'none'; base-uri 'self'" />
 
     <meta property="og:image" content="assets/images/hero.png" />
 
@@ -30,7 +30,7 @@
     <link rel="stylesheet" href="css/style.css" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7PNPWV5C4V"></script>
-    <script src="js/analytics.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts="></script>
+    <script src="js/analytics.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk="></script>
   </head>
   <body>
     <!-- Navigation Bar -->
@@ -379,7 +379,7 @@
     </footer>
 
     <!-- JavaScript -->
-    <script src="js/blogPosts.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts=" defer></script>
-    <script src="js/main.js" nonce="sEUe4da2S7sdSiqsNe2zui6B3xj34wbWFbeyX46p4ts=" defer></script>
+    <script src="js/blogPosts.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk=" defer></script>
+    <script src="js/main.js" nonce="o9BwS5sNfyRqgxmv2pYp2o4QtGNxBFIW/Rm4H/0W/tk=" defer></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "js/main.js",
   "scripts": {
     "test": "node --test",
-    "build": "node scripts/generateNonce.js"
+    "build": "node scripts/generateProperNonce.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/generateProperNonce.js
+++ b/scripts/generateProperNonce.js
@@ -49,20 +49,18 @@ htmlFiles.forEach((file) => {
     `$1${cspPolicy}$3`
   );
 
-  // Remove ALL existing nonce attributes first to prevent duplicates
-  content = content.replace(/\s*nonce="[^"]*"/g, '');
+    // Add nonce to ALL local script tags, replacing any existing nonce
+    content = content.replace(
+      /<script([^>]*)\s+src="(?!https?:|\/\/)([^"]*)"([^>]*?)>/g,
+      (match, before, src, after) => {
+        // Remove any existing nonce attributes in captured groups
+        const cleanBefore = before.replace(/\s*nonce="[^"]*"/gi, '').trim();
+        const cleanAfter = after.replace(/\s*nonce="[^"]*"/gi, '').trim();
 
-  // Add nonce to ALL script tags with src attributes (local scripts)
-  content = content.replace(
-    /<script([^>]*)\s+src="(js\/[^"]*)"([^>]*?)>/g,
-    (match, before, src, after) => {
-      // Clean up any extra spaces and ensure proper formatting
-      const cleanBefore = before.trim();
-      const cleanAfter = after.trim();
-      
-      return `<script${cleanBefore ? ' ' + cleanBefore : ''} src="${src}" nonce="${nonce}"${cleanAfter ? ' ' + cleanAfter : ''}>`;
-    }
-  );
+        // Reconstruct the script tag without altering the src attribute
+        return `<script${cleanBefore ? ' ' + cleanBefore : ''} src="${src}" nonce="${nonce}"${cleanAfter ? ' ' + cleanAfter : ''}>`;
+      }
+    );
 
   fs.writeFileSync(file, content);
   console.log(`Updated ${file}`);


### PR DESCRIPTION
## Summary
- Swap build script to `generateProperNonce.js`.
- Simplify nonce injection to a single regex that preserves each script's `src`, including relative paths.
- Regenerate CSP and script nonces across pages.

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c89bcc6088330bdcc2969671713f4