### PR TITLE
Load Google Analytics only in production

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     
     <!-- Google Analytics -->
-    {% if site.google_analytics %}
+    {% if jekyll.environment == 'production' and site.google_analytics %}
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary
- Load Google Analytics only when Jekyll runs in production

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68b7060978d8833095e4117a385a9dc1