### PR TITLE
streamline header by removing duplicate tagline

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,16 +48,16 @@
   <body>
     <header>
       <div class="container">
-        <a id="a-title" href="{{ '/' | relative_url }}">
-          <h1>{{ site.title | default: site.github.repository_name }}</h1>
-        </a>
-        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
-
         <nav class="header-nav">
-          <a href="{{ '/' | relative_url }}" class="nav-link">Home</a>
-          <a href="{{ '/blog/' | relative_url }}" class="nav-link">Blog</a>
-          <a href="{{ '/assets/resume.pdf' | relative_url }}" class="nav-link" target="_blank">CV</a>
-          <button id="themeToggle" class="theme-toggle" type="button" aria-label="Switch to light mode" aria-pressed="false">☀️</button>
+          <a id="a-title" href="{{ '/' | relative_url }}" class="site-brand">
+            <span class="brand-name">{{ site.title | default: site.github.repository_name }}</span>
+          </a>
+          <div class="nav-links">
+            <a href="{{ '/' | relative_url }}" class="nav-link">Home</a>
+            <a href="{{ '/blog/' | relative_url }}" class="nav-link">Blog</a>
+            <a href="{{ '/assets/resume.pdf' | relative_url }}" class="nav-link" target="_blank">CV</a>
+            <button id="themeToggle" class="theme-toggle" type="button" aria-label="Switch to light mode" aria-pressed="false">☀️</button>
+          </div>
         </nav>
       </div>
     </header>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -10,13 +10,37 @@
 
 /* Header navigation styling */
 .header-nav {
-  margin-top: 1rem;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+}
+
+.site-brand {
+  text-decoration: none;
+}
+
+.brand-name {
+  color: var(--hacker-green);
+  font-size: 1.4rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  transition: all 0.3s ease;
+}
+
+.brand-name:hover {
+  text-shadow: 0 0 15px var(--hacker-green);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .nav-link {
   display: inline-block;
-  margin: 0 1rem;
   padding: 0.5rem 1rem;
   color: #00ff00;
   text-decoration: none;
@@ -25,13 +49,25 @@
   transition: all 0.3s ease;
   text-transform: uppercase;
   letter-spacing: 1px;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
 
 .nav-link:hover {
   background: #00ff00;
   color: #000;
   box-shadow: 0 0 15px #00ff00;
+}
+
+@media (max-width: 768px) {
+  .header-nav {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .nav-links {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
 }
 
 /* Theme toggle button */


### PR DESCRIPTION
- Remove tagline from header, keep only brand name as nav logo
- Restructure header with brand on left, nav links on right
- Hero section now serves as the main introduction
- Add responsive styles for mobile header