### PR TITLE
Let investigation headers scroll naturally

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,6 +44,8 @@
   {% assign page_kind = 'default' %}
   {% if page.url == '/' %}
     {% assign page_kind = 'home' %}
+  {% elsif page.layout == 'investigation' %}
+    {% assign page_kind = 'investigation' %}
   {% elsif page.layout == 'post' %}
     {% assign page_kind = 'post' %}
   {% elsif page.url contains '/blog' %}
@@ -57,7 +59,7 @@
         <span class="strip-right">OSINT · MITRE ATT&amp;CK · DFIR · Est. 2025</span>
       </div>
     </div>
-    <header>
+    <header class="site-header">
       <div class="container">
         <nav class="header-nav" aria-label="Main navigation">
           <a id="a-title" href="{{ '/' | relative_url }}" class="site-brand">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -242,7 +242,7 @@ main#main_content { padding: 0; }
 }
 
 /* ---------- Header / nav ---------- */
-header {
+.site-header {
   position: sticky;
   top: 0;
   z-index: 50;
@@ -250,6 +250,16 @@ header {
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--line);
+}
+
+/* Keep report reading unobstructed: all headers scroll with the document. */
+body[data-page="investigation"] .site-header,
+body[data-page="investigation"] .post-header {
+  position: static;
+  top: auto;
+  z-index: auto;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .header-nav {
@@ -1934,7 +1944,7 @@ summary:focus-visible {
   .footer-legal { flex-direction: column; gap: 0.5rem; }
 
   /* Reading pages: let the header scroll away for more room */
-  body[data-page="post"] header { position: static; backdrop-filter: none; }
+  body[data-page="post"] .site-header { position: static; backdrop-filter: none; }
 }
 
 /* =====================================================================


### PR DESCRIPTION
## Summary

- scope sticky positioning to the site navigation
- make the navigation and report header scroll away on investigation pages
- preserve the existing responsive post behavior

## Validation

- git diff --check